### PR TITLE
Use Heroku instance of gatekeeper

### DIFF
--- a/src/GoalSetter.js
+++ b/src/GoalSetter.js
@@ -15,7 +15,7 @@ class GoalSetter extends Component {
   }
 
   authenticate() {
-    const gatekeeperURI = process.env.REACT_APP_GATEKEEPER_URI
+    const gatekeeperURI = "https://goal-setter-gatekeeper.herokuapp.com" 
     const code =
       window.location.href.match(/\?code=(.*)/) &&
       window.location.href.match(/\?code=(.*)/)[1];
@@ -31,8 +31,8 @@ class GoalSetter extends Component {
   }
 
   logIn = () => {
-    const CLIENT_ID = process.env.REACT_APP_OAUTH_CLIENT_ID;
-    const REDIRECT_URI = process.env.REACT_APP_REDIRECT_URI;
+    const CLIENT_ID = "4e410133f13ab993865f";
+    const REDIRECT_URI = "http://localhost:3000";
 
     window.location.replace(`https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&scope=repo,user&redirect_uri=${REDIRECT_URI}`)
     this.authenticate();

--- a/src/test/GoalSetter.test.js
+++ b/src/test/GoalSetter.test.js
@@ -32,7 +32,6 @@ it('passes correct props to Authenticate', () => {
 });
 
 it('fetches the token when code is present', () => {
-  process.env.REACT_APP_GATEKEEPER_URI = 'anything.com'
   window.history.pushState({}, 'Anything', '/?code=123');
 
   const mockSuccessResponse = {};


### PR DESCRIPTION
This change hard codes the URL for gatekeeper that I have deployed on
Heroku for ease of development for others. Now developers no longer need
to run their own instance of gatekeeper or create their own GitHub OAuth
app.